### PR TITLE
Allow for PostCSS plugins

### DIFF
--- a/src/commands/PostCSSCommand.js
+++ b/src/commands/PostCSSCommand.js
@@ -48,11 +48,12 @@ class PostCSSAction extends Action {
     const src = this.src
     const dest = this.dest
     // const opts = this.opts
-    const plugins = [postcssImport({
+    const plugins = this.opts.plugins || []
+    plugins.unshift(postcssImport({
       onImport: (files) => {
         this._onImport(files)
       }
-    })]
+    }))
     if (this.opts.variables) {
       plugins.push(postcssVariables())
     }


### PR DESCRIPTION
Hi,

Thanks for a great library in Substance.

Following your suggested setup approach using substance-bundler I ran into a scenario where I'd like to add plugins to the PostCSS action.

This should facilitate such cases without interfering with the usual process.